### PR TITLE
fix error during creating mappings (Cannot instantiate interface Diva…

### DIFF
--- a/src/module-vsbridge-indexer-tax/Index/Mapping/Tax.php
+++ b/src/module-vsbridge-indexer-tax/Index/Mapping/Tax.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @package   magento-2-1.dev
+ * @author    Vladimir Plastovets <vladimir.plastovets@phoenix-media.eu>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license   See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Divante\VsbridgeIndexerTax\Index\Mapping;
+
+use Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface;
+use Divante\VsbridgeIndexerCore\Api\MappingInterface;
+use Magento\Framework\Event\ManagerInterface as EventManager;
+
+/**
+ * Class Tax
+ * @package Divante\VsbridgeIndexerTax\Index\Mapping
+ */
+class Tax implements MappingInterface
+{
+
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * CmsBlock constructor.
+     *
+     * @param EventManager $eventManager
+     */
+    public function __construct(EventManager $eventManager)
+    {
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setType(string $type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMappingProperties()
+    {
+        $properties = [
+            'id'                     => ['type' => FieldInterface::TYPE_LONG],
+            'code'                   => ['type' => FieldInterface::TYPE_TEXT],
+            'position'               => ['type' => FieldInterface::TYPE_LONG],
+            'priority'               => ['type' => FieldInterface::TYPE_TEXT],
+            'calculate_subtotal'     => ['type' => FieldInterface::TYPE_TEXT],
+            'product_tax_class_ids'  => ['type' => FieldInterface::TYPE_LONG],
+            'customer_tax_class_ids' => ['type' => FieldInterface::TYPE_LONG]
+        ];
+
+        $properties['rates'] = [
+            'properties' => [
+                'id'             => ['type' => FieldInterface::TYPE_LONG],
+                'code'           => ['type' => FieldInterface::TYPE_TEXT],
+                'rate'           => ['type' => FieldInterface::TYPE_TEXT],
+                'tax_postcode'   => ['type' => FieldInterface::TYPE_TEXT],
+                'tax_region_id'  => ['type' => FieldInterface::TYPE_TEXT],
+                'tax_country_id' => ['type' => FieldInterface::TYPE_TEXT]
+            ]
+        ];
+
+        $mappingObject = new \Magento\Framework\DataObject();
+        $mappingObject->setData('properties', $properties);
+
+        $this->eventManager->dispatch(
+            'elasticsearch_tax_mapping_properties',
+            ['mapping' => $mappingObject]
+        );
+
+        return $mappingObject->getData();
+    }
+}

--- a/src/module-vsbridge-indexer-tax/etc/vsbridge_indices.xml
+++ b/src/module-vsbridge-indexer-tax/etc/vsbridge_indices.xml
@@ -2,7 +2,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Divante_VsbridgeIndexerCore:etc/vsbridge_indices.xsd">
 
     <index identifier="vue_storefront_catalog">
-        <type name="taxrule">
+        <type name="taxrule" mapping="Divante\VsbridgeIndexerTax\Index\Mapping\Tax">
             <data_providers>
                 <data_provider name="tax_classes">Divante\VsbridgeIndexerTax\Model\Indexer\DataProvider\TaxClasses</data_provider>
                 <data_provider name="tax_rates">Divante\VsbridgeIndexerTax\Model\Indexer\DataProvider\TaxRates</data_provider>


### PR DESCRIPTION
Fixed error during create mappings.
`Fatal error: Uncaught Error: Cannot instantiate interface Divante\VsbridgeIndexerCore\Api\MappingInterface in /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php on line 111`