### PR TITLE
added enable_https_mode to client options

### DIFF
--- a/src/module-vsbridge-indexer-core/Elasticsearch/ClientConfiguration.php
+++ b/src/module-vsbridge-indexer-core/Elasticsearch/ClientConfiguration.php
@@ -42,6 +42,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'host' => $this->getHost(),
             'port' => $this->getPort(),
             'scheme' => $this->getScheme(),
+            'enable_https_mode' => $this->isHttpsModeEnabled(),
             'enable_http_auth' => $this->isHttpAuthEnabled(),
             'auth_user' => $this->getHttpAuthUser(),
             'auth_pwd' => $this->getHttpAuthPassword(),
@@ -72,6 +73,16 @@ class ClientConfiguration implements ClientConfigurationInterface
     public function getScheme()
     {
         return (bool)$this->getConfigParam('enable_https_mode') ? 'https' : 'http';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHttpsModeEnabled()
+    {
+        $httpsModeEnabled = (bool)$this->getConfigParam('enable_https_mode');
+
+        return $httpsModeEnabled;
     }
 
     /**


### PR DESCRIPTION
I've added enable_https_mode config to client builder because we try to use it in: 
`src/module-vsbridge-indexer-core/Elasticsearch/ClientBuilder.php:getHost(array $options)`
but in array of options this configuration is missing, after that we always set schema to http.
