### PR TITLE
Add support for video data #19. Minor refactoring.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,9 +1,9 @@
 # Changelog
 
-## 1.1.0
+## [Unreleased]
+- Adding support for video data. Small change will be needed in VSF #19
 
-
-## 1.0.0 (2019.04.03)
+## [1.0.0] (2019.04.03)
 First version
 
 ## March 2019

--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
@@ -149,6 +149,16 @@ class Product extends AbstractMapping implements MappingInterface
                 'image' => ['type' => FieldInterface::TYPE_TEXT],
                 'lab' => ['type' => FieldInterface::TYPE_TEXT],
                 'pos' => ['type' => FieldInterface::TYPE_TEXT],
+                'vid' => [
+                    'properties' => [
+                        'url' =>  ['type' => FieldInterface::TYPE_TEXT],
+                        'title' =>  ['type' => FieldInterface::TYPE_TEXT],
+                        'desc' =>  ['type' => FieldInterface::TYPE_TEXT],
+                        'video_id' =>  ['type' => FieldInterface::TYPE_TEXT],
+                        'meta' =>  ['type' => FieldInterface::TYPE_TEXT],
+                        'type' =>  ['type' => FieldInterface::TYPE_TEXT],
+                    ]
+                ]
             ],
         ];
         $attributesMapping['final_price'] = ['type' => FieldInterface::TYPE_DOUBLE];

--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Category/AttributeData.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Category/AttributeData.php
@@ -168,7 +168,7 @@ class AttributeData
 
     /**
      * @param array $categories
-     * @param       $rootId
+     * @param int $rootId
      *
      * @return array
      */

--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Product/ConfigurableData.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Product/ConfigurableData.php
@@ -129,7 +129,7 @@ class ConfigurableData implements DataProviderInterface
 
     /**
      * @param array $indexData
-     * @param $storeId
+     * @param int $storeId
      *
      * @return array
      * @throws \Exception
@@ -299,7 +299,7 @@ class ConfigurableData implements DataProviderInterface
     }
 
     /**
-     * @param $storeId
+     * @param int $storeId
      * @param array $allChildren
      * @param array $requiredAttributes
      *
@@ -345,11 +345,11 @@ class ConfigurableData implements DataProviderInterface
 
     /**
      * @param array $documents
-     * @param $size
+     * @param int $batchSize
      *
      * @return \Generator
      */
-    private function getChildrenInBatches(array $documents, $size)
+    private function getChildrenInBatches(array $documents, $batchSize)
     {
         $i = 0;
         $batch = [];
@@ -357,7 +357,7 @@ class ConfigurableData implements DataProviderInterface
         foreach ($documents as $documentName => $documentValue) {
             $batch[$documentName] = $documentValue;
 
-            if (++$i == $size) {
+            if (++$i == $batchSize) {
                 yield $batch;
                 $i = 0;
                 $batch = [];

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category.php
@@ -77,9 +77,11 @@ class Category
     }
 
     /**
-     * @param $storeId
+     * @param int $storeId
      *
      * @return \Magento\Framework\DB\Select
+     * @throws \Exception
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function filterByStore($storeId)
     {
@@ -103,7 +105,7 @@ class Category
     }
 
     /**
-     * @param $storeId
+     * @param int $storeId
      * @param array $productIds
      *
      * @return array

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category/Children.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category/Children.php
@@ -65,7 +65,7 @@ class Children
 
     /**
      * @param array $category
-     * @param $storeId
+     * @param int $storeId
      *
      * @return array
      * @throws \Exception
@@ -88,7 +88,7 @@ class Children
 
     /**
      * @param array $category
-     * @param $storeId
+     * @param int $storeId
      * @param bool $recursive
      *
      * @return array

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product.php
@@ -65,6 +65,7 @@ class Product
      * @param AttributeDataProvider $attributeDataProvider
      * @param ResourceConnection $resourceConnection
      * @param StoreManagerInterface $storeManager
+     * @param ProductMetaData $productMetaData
      * @param DbHelper $dbHelper
      */
     public function __construct(
@@ -90,6 +91,7 @@ class Product
      * @param int $limit
      *
      * @return array
+     * @throws \Exception
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
@@ -203,7 +205,7 @@ class Product
     }
 
     /**
-     * @param $storeId
+     * @param int $storeId
      *
      * @return int
      * @throws \Magento\Framework\Exception\NoSuchEntityException

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Links.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Links.php
@@ -71,6 +71,8 @@ class Links
 
     /**
      * @param array $products
+     *
+     * @return void
      */
     public function setProducts(array $products)
     {

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/TierPrices.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/TierPrices.php
@@ -32,6 +32,7 @@ class TierPrices
      * TierPrices constructor.
      *
      * @param ResourceConnection $resourceModel
+     * @param ProductMetaData $productMetaData
      */
     public function __construct(
         ResourceConnection $resourceModel,
@@ -46,6 +47,7 @@ class TierPrices
      * @param array $linkFieldIds
      *
      * @return array
+     * @throws \Exception
      */
     public function loadTierPrices($websiteId, array $linkFieldIds)
     {

--- a/src/module-vsbridge-indexer-catalog/Model/TierPriceProcessor.php
+++ b/src/module-vsbridge-indexer-catalog/Model/TierPriceProcessor.php
@@ -77,7 +77,7 @@ class TierPriceProcessor
 
     /**
      * @param array $indexData
-     * @param $storeId
+     * @param int $storeId
      *
      * @return array
      * @throws \Exception

--- a/src/module-vsbridge-indexer-catalog/Plugin/Indexer/Category/Save/UpdateCategoryData.php
+++ b/src/module-vsbridge-indexer-catalog/Plugin/Indexer/Category/Save/UpdateCategoryData.php
@@ -35,6 +35,8 @@ class UpdateCategoryData
      * Reindex data after product save/delete resource commit
      *
      * @param Category $category
+     *
+     * @return void
      */
     public function afterReindex(Category $category)
     {

--- a/src/module-vsbridge-indexer-catalog/Plugin/Indexer/Product/Save/UpdateProductData.php
+++ b/src/module-vsbridge-indexer-catalog/Plugin/Indexer/Product/Save/UpdateProductData.php
@@ -33,7 +33,10 @@ class UpdateProductData
 
     /**
      * Reindex data after product save/delete resource commit
+     *
      * @param Product $product
+     *
+     * @return void
      */
     public function afterReindex(Product $product)
     {


### PR DESCRIPTION
A small change will be required in VSF to make it work
https://github.com/afirlejczyk/vue-storefront/commit/bb2e79db8744ff4e71d8c4f35818410e246e79ab

`id` field is mapped by default as a number, but for youtube video, we have a text.
We shouldn't mix mapping for the same field in ES 5.x.
It is better to set video ID to a new field e.g: 'video_id'. 
I will also make a change in mage2vuestorefront.