### PR TITLE
Fix query building in cleanUpByTransactionKey to solve problem with es

### DIFF
--- a/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
@@ -161,7 +161,7 @@ class GenericIndexerHandler
             $query = ['query' => ['bool' => $transactionKeyQuery]];
 
             if ($docIds) {
-                $query['query']['bool']['must']['terms'] = ['_id' => $docIds];
+                $query['query']['bool']['must']['terms'] = ['_id' => array_values($docIds)];
             }
 
             $query = [


### PR DESCRIPTION
I got an error because `/magento/vendor/magento/module-inventory-sales/Observer/CatalogInventory/RevertQuoteInventoryObserver.php(66)` send `$productIds` with key-value array. It breaks elasticsearch query generation in
`/magento/vendor/divante/magento2-vsbridge-indexer/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php(164)`