### PR TITLE
Fix bug causing empty product URL paths

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fix bug causing empty product URL paths  - [@indiebytes](https://github.com/indiebytes) ([#63](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/63))
+
 ### Added
 - Adding support for video data. Small change will be needed in VSF #19
 - Add support for "product_count" in category. When products are reassign to category, category data is not updated automatically in ES.

--- a/src/module-vsbridge-indexer-catalog/Model/ProductUrlPathGenerator.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ProductUrlPathGenerator.php
@@ -74,7 +74,7 @@ class ProductUrlPathGenerator
     private function getProductUrlSuffix()
     {
         if (null === $this->productUrlSuffix) {
-            $this->productUrlSuffix = $this->scopeConfig->getValue(
+            $this->productUrlSuffix = (string) $this->scopeConfig->getValue(
                 \Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator::XML_PATH_PRODUCT_URL_SUFFIX
             );
         }

--- a/src/module-vsbridge-indexer-catalog/Model/ProductUrlPathGenerator.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ProductUrlPathGenerator.php
@@ -46,6 +46,8 @@ class ProductUrlPathGenerator
     }
 
     /**
+     * Add URL path
+     *
      * @param array $products
      * @param int $storeId
      *
@@ -59,7 +61,10 @@ class ProductUrlPathGenerator
         $rewrites = $this->rewriteResource->getRawRewritesData($productIds, $storeId);
 
         foreach ($rewrites as $productId => $rewrite) {
-            $rewrite = mb_substr($rewrite, 0, -strlen($urlSuffix));
+            if ($urlSuffix != "") {
+                $rewrite = mb_substr($rewrite, 0, -strlen($urlSuffix));
+            }
+
             $products[$productId]['url_path'] = $rewrite;
         }
 


### PR DESCRIPTION
Resolves issue #63:

> If `Divante\VsbridgeIndexerCatalog\Model::getProductUrlSuffix()` returns `null` it will cause an issue in `Divante\VsbridgeIndexerCatalog\Model::addUrlPath()`.
> 
> ```
> $rewrite = mb_substr($rewrite, 0, -strlen($urlSuffix));
> ```
> 
> `strlen(null)` will return `0` which in turn leads to `mb_substr()` returning an empty string which will be indexed as `url_path` for the product.

This pull request also contain a minor update that cast `$this->productUrlSuffix` to string once it's fetched from Magento config.