### PR TITLE
Make ElasticSearch Password obscure/encrypted/secure

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix bug causing empty product URL paths  - [@indiebytes](https://github.com/indiebytes) ([#63](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/63))
+- Changed ElasticSearch password to be obscured, encrypted, and considered sensitive (will dump to `env.php` instead of `config.php`) - [@rain2o](https://github.com/rain2o) ([#69](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/69))
 
 ### Added
 - Adding support for video data. Small change will be needed in VSF #19

--- a/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
+++ b/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
@@ -56,11 +56,12 @@
                         <field id="enable_http_auth">1</field>
                     </depends>
                 </field>
-                <field id="auth_pwd" translate="label comment" type="text" sortOrder="61" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="auth_pwd" translate="label comment" type="obscure" sortOrder="61" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Basic HTTP authentication password</label>
                     <depends>
                         <field id="enable_http_auth">1</field>
                     </depends>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
             </group>
 

--- a/src/module-vsbridge-indexer-core/etc/config.xml
+++ b/src/module-vsbridge-indexer-core/etc/config.xml
@@ -13,6 +13,7 @@
             <es_client>
                 <host>127.0.0.1</host>
                 <port>9200</port>
+                <auth_pwd backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
             </es_client>
             <indices_settings>
                 <batch_indexing_size>1000</batch_indexing_size>

--- a/src/module-vsbridge-indexer-core/etc/di.xml
+++ b/src/module-vsbridge-indexer-core/etc/di.xml
@@ -50,4 +50,13 @@
             <argument name="logger" xsi:type="object">Divante\VsbridgeIndexerCore\Cache\Logger\CacheLogger</argument>
         </arguments>
     </type>
+
+    <!-- Prevent sensitive fields from getting dumped with store config -->
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="vsbridge_indexer_settings/es_client/auth_pwd" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Closes #69 

This changes the ElasticSearch password field to be field type `obscure` which will show dots instead of the actual value. It also adds the backend model of `Encrypted` so it is encrypted before saved in the database. And it adds this field to the `sensitive` TypePool which tells Magento not to dump it to `app/etc/config.php` when running `bin/magento app:config:dump`. This file is intended to be tracked in Git and should not contain credentials or other sensitive data. It will now dump it to `app/etc/env.php` which should _not_ be tracked in git and should be managed in each environment separately.

**Note** - Because this field is changing its backend model anyone currently using this module will need to set the password in that field again after this update. While inconvenient it does force users to re-save the password so that it will be encrypted and more secure.