### PR TITLE
Set store when rebuilding cms blocks and pages

### DIFF
--- a/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsBlock.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsBlock.php
@@ -14,6 +14,7 @@ use Divante\VsbridgeIndexerCms\Model\ResourceModel\CmsBlock as CmsBlockResource;
 use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaList;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class CmsBlock
@@ -41,6 +42,11 @@ class CmsBlock
     private $contentProcessor;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * CmsBlock constructor.
      *
      * @param AreaList $areaList
@@ -52,12 +58,14 @@ class CmsBlock
         AreaList $areaList,
         ContentProcessorInterface $contentProcessor,
         CmsBlockResource $cmsBlockResource,
-        FilterProvider $filterProvider
+        FilterProvider $filterProvider,
+        StoreManagerInterface $storeManager
     ) {
         $this->areaList = $areaList;
         $this->filterProvider = $filterProvider;
         $this->resourceModel = $cmsBlockResource;
         $this->contentProcessor = $contentProcessor;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -69,6 +77,13 @@ class CmsBlock
     public function rebuild($storeId = 1, array $blockIds = [])
     {
         $this->areaList->getArea(Area::AREA_FRONTEND)->load(Area::PART_DESIGN);
+
+        $storeCode = $this->storeManager->getStore($storeId)->getCode();
+
+        if ($storeCode) {
+            $this->storeManager->setCurrentStore($storeCode);
+        }
+
         $templateFilter = $this->filterProvider->getBlockFilter()->setStoreId($storeId);
         $lastBlockId = 0;
 

--- a/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsPage.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsPage.php
@@ -14,6 +14,7 @@ use Divante\VsbridgeIndexerCms\Model\ResourceModel\CmsPage as CmsPageResource;
 use Magento\Cms\Model\Template\FilterProvider;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaList;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class CmsPage
@@ -41,6 +42,11 @@ class CmsPage
     private $contentProcessor;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * CmsBlock constructor.
      *
      * @param AreaList $areaList
@@ -52,12 +58,14 @@ class CmsPage
         AreaList $areaList,
         ContentProcessorInterface $contentProcessor,
         CmsPageResource $cmsBlockResource,
-        FilterProvider $filterProvider
+        FilterProvider $filterProvider,
+        StoreManagerInterface $storeManager
     ) {
         $this->areaList = $areaList;
         $this->resourceModel = $cmsBlockResource;
         $this->filterProvider = $filterProvider;
         $this->contentProcessor = $contentProcessor;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -69,6 +77,12 @@ class CmsPage
     public function rebuild($storeId = 1, array $pageIds = [])
     {
         $this->areaList->getArea(Area::AREA_FRONTEND)->load(Area::PART_DESIGN);
+        $storeCode = $this->storeManager->getStore($storeId)->getCode();
+
+        if ($storeCode) {
+            $this->storeManager->setCurrentStore($storeCode);
+        }
+
         $templateFilter = $this->filterProvider->getPageFilter()->setStoreId($storeId);
         $lastPageId = 0;
 


### PR DESCRIPTION
This PR sets the current store when rebuilding a CMS Page or Block. It's necessary for example when adding a productlist widget to a page/block as in the ProductsList.php Widget Block the product collection is supposed to have a store.
https://github.com/magento/magento2/blob/3495a0504001e88ac769499619fc27b7212bab49/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php#L305

```php
if ($this->getData('store_id') !== null) {
    $collection->setStoreId($this->getData('store_id'));
}
```