### PR TITLE
Fix uncaught TypeError in CMS indexer

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Uncaught TypeError in CMS indexer  - [@indiebytes](https://github.com/indiebytes) ([#85](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/85))
 
 ## [1.1.0] (2019.07.10)
 

--- a/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsBlock.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsBlock.php
@@ -78,7 +78,7 @@ class CmsBlock
             foreach ($cmsBlocks as $blockData) {
                 $lastBlockId = $blockData['block_id'];
                 $blockData['id'] = $blockData['block_id'];
-                $blockData['content'] = $this->contentProcessor->parse($templateFilter, $blockData['content']);
+                $blockData['content'] = $this->contentProcessor->parse($templateFilter, (string) $blockData['content']);
                 $blockData['active'] = (bool)$blockData['is_active'];
 
                 unset($blockData['creation_time'], $blockData['update_time'], $blockData['block_id']);

--- a/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsPage.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/Action/CmsPage.php
@@ -78,7 +78,7 @@ class CmsPage
             foreach ($cmsPages as $pageData) {
                 $lastPageId = $pageData['page_id'];
                 $pageData['id'] = $pageData['page_id'];
-                $pageData['content'] = $this->contentProcessor->parse($templateFilter, $pageData['content']);
+                $pageData['content'] = $this->contentProcessor->parse($templateFilter, (string) $pageData['content']);
                 $pageData['active'] = (bool)$pageData['is_active'];
 
                 unset($pageData['creation_time'], $pageData['update_time'], $pageData['page_id']);


### PR DESCRIPTION
Fixes issue #85 by casting content to string to avoid null values.