### PR TITLE
Multiselect attribute values fix

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Uncaught TypeError in CMS indexer  - [@indiebytes](https://github.com/indiebytes) ([#85](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/85))
+- Multiselect attribute values check if they are numeric before casting to `int` type to avoid casting strings to `int` and therefore causing the value to be `0` always. - [@rain2o](https://github.com/rain2o)
 
 ## [1.1.0] (2019.07.10)
 

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
@@ -155,7 +155,7 @@ abstract class AbstractEavAttributes implements EavAttributesInterface
                 $options = explode(',', $value['value']);
 
                 if (!empty($options)) {
-                    $options = array_map('intval', $options);
+                    $options = array_map([$this, 'parseValue'], $options);
                 }
 
                 $value['value'] = $options;
@@ -166,6 +166,19 @@ abstract class AbstractEavAttributes implements EavAttributesInterface
         }
 
         return $this->valuesByEntityId;
+    }
+
+    /**
+     * Parse the option value - Cast to int if it's numeric
+     * otherwise leave it as-is
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function parseValue($value)
+    {
+        return is_numeric($value) ? intval($value) : $value;
     }
 
     /**


### PR DESCRIPTION
This is an additional update to #75 . 

There are scenarios where a multiselect attribute can have text values instead of integers. Typically it will be an integer because it will be the ID of the value. However, if the multiselect source is an array of hard-coded values the key can be an integer or a string. For example 
 [\Magento\Catalog\Model\Category\Attribute\Source\Mode](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Category/Attribute/Source/Mode.php). This approach is used sometimes by extension or theme developers who have a need for a multiselect attribute with values that will not change and therefore do not need to be dynamic.

This update simply checks to see if the value is numeric before running `intval`. If it's not numeric it just returns the original value.