### PR TITLE
Inject proxies in di.xml for lazy loading.

### DIFF
--- a/src/module-vsbridge-indexer-core/Console/Command/RebuildEsIndexCommand.php
+++ b/src/module-vsbridge-indexer-core/Console/Command/RebuildEsIndexCommand.php
@@ -64,10 +64,10 @@ class RebuildEsIndexCommand extends Command
      */
     public function __construct(
         IndexerRegistry $indexerRegistry,
-        IndexOperations\Proxy $indexOperations,
-        StoreManagerInterface\Proxy $storeManager,
-        \Magento\Framework\App\State\Proxy $state,
-        \Magento\Indexer\Model\Indexer\CollectionFactory\Proxy $collectionFactory
+        IndexOperations $indexOperations,
+        StoreManagerInterface $storeManager,
+        \Magento\Framework\App\State $state,
+        \Magento\Indexer\Model\Indexer\CollectionFactory $collectionFactory
     ) {
         $this->indexerRegistry = $indexerRegistry;
         $this->collectionFactory = $collectionFactory;

--- a/src/module-vsbridge-indexer-core/etc/di.xml
+++ b/src/module-vsbridge-indexer-core/etc/di.xml
@@ -67,4 +67,14 @@
             </argument>
         </arguments>
     </type>
+
+    <!-- Lazy load proxies -->
+    <type name="Divante\VsbridgeIndexerCore\Console\Command\RebuildEsIndexCommand">
+        <arguments>
+            <argument name="indexOperations" xsi:type="object">Divante\VsbridgeIndexerCore\Index\IndexOperations\Proxy</argument>
+            <argument name="storeManager" xsi:type="object">Magento\Store\Model\StoreManagerInterface\Proxy</argument>
+            <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>
+            <argument name="collectionFactory" xsi:type="object">Magento\Indexer\Model\Indexer\CollectionFactory\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Closes #94 

Per Magento's coding standards Proxies must be lazy loaded using `di.xml` because they are generated classes.