### PR TITLE
Skip exporting configurable products without super attributes. 

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed/Improved
+- Skip exporting configurable products without "configurable_options".
+
 ## [1.2.0] (2019.08.05)
 
 ### Fixed
@@ -27,7 +30,7 @@
 
 ### Changed/Improved
 - Change mapping for "category.name" field in product type
-- Remove dependency from catalog_product_price and cataloginventory_stock indexer. On product save multiple request has been send   
+- Remove dependency from catalog_product_price and cataloginventory_stock indexer. On product save multiple request has been send to ES
 - Change "Use Short Catalog Urls" setting option to "Use Catalog Url Keys" 
 - Add option to generate product/category slug base on Magento Url Key and ID. By default slug (and url_key) field is generated base on NAME and ID.
 

--- a/src/module-vsbridge-indexer-catalog/Logger/CatalogIndexerLogger.php
+++ b/src/module-vsbridge-indexer-catalog/Logger/CatalogIndexerLogger.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package  Divante\VsbridgeIndexerCatalog
+ * @author Agata Firlejczyk <afirlejczyk@divante.pl>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Divante\VsbridgeIndexerCatalog\Logger;
+
+use Monolog\Logger;
+
+/**
+ * Class CatalogIndexerLogger
+ */
+class CatalogIndexerLogger extends Logger
+{
+}

--- a/src/module-vsbridge-indexer-catalog/Logger/Handler/Error.php
+++ b/src/module-vsbridge-indexer-catalog/Logger/Handler/Error.php
@@ -1,30 +1,30 @@
 <?php
 /**
- * @package  Divante\VsbridgeIndexerCore
+ * @package  Divante\VsbridgeIndexerCatalog
  * @author Agata Firlejczyk <afirlejczyk@divante.pl>
  * @copyright 2019 Divante Sp. z o.o.
  * @license See LICENSE_DIVANTE.txt for license details.
  */
 
-namespace Divante\VsbridgeIndexerCore\Logger\Handler;
+namespace Divante\VsbridgeIndexerCatalog\Logger\Handler;
 
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Logger;
 
 /**
- * Class Info
+ * Class Error
  */
-class Info extends Base
+class Error extends Base
 {
     /**
      * Logging level
      * @var int
      */
-    protected $loggerType = Logger::INFO;
+    protected $loggerType = Logger::ERROR;
 
     /**
      * File name
      * @var string
      */
-    protected $fileName = '/var/log/vsbridge-indexer/info.log';
+    protected $fileName = '/var/log/vsbridge-indexer/catalog_error.log';
 }

--- a/src/module-vsbridge-indexer-catalog/etc/di.xml
+++ b/src/module-vsbridge-indexer-catalog/etc/di.xml
@@ -5,8 +5,21 @@
     <preference for="Divante\VsbridgeIndexerCatalog\Api\SlugGeneratorInterface" type="Divante\VsbridgeIndexerCatalog\Model\SlugGenerator"/>
     <preference for="Divante\VsbridgeIndexerCatalog\Api\Data\CatalogConfigurationInterface" type="Divante\VsbridgeIndexerCatalog\Model\Settings"/>
     <preference for="Divante\VsbridgeIndexerCatalog\Api\ApplyCategorySlugInterface" type="Divante\VsbridgeIndexerCatalog\Model\Category\ApplyCategorySlug"/>
-
     <preference for="Divante\VsbridgeIndexerCatalog\Api\LoadInventoryInterface" type="Divante\VsbridgeIndexerCatalog\Model\LoadInventory"/>
+
+    <type name="Divante\VsbridgeIndexerCatalog\Logger\CatalogIndexerLogger">
+        <arguments>
+            <argument name="name" xsi:type="string">vsbridgeCatalogIndexerLogger</argument>
+            <argument name="handlers"  xsi:type="array">
+                <item name="error" xsi:type="object">Divante\VsbridgeIndexerCatalog\Logger\Handler\Error</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Divante\VsbridgeIndexerCatalog\Model\ResourceModel\Product\Configurable">
+        <arguments>
+            <argument name="logger" xsi:type="object">Divante\VsbridgeIndexerCatalog\Logger\CatalogIndexerLogger</argument>
+        </arguments>
+    </type>
 
     <type name="Divante\VsbridgeIndexerCatalog\Model\Indexer\DataProvider\Product\ConfigurableData">
         <arguments>

--- a/src/module-vsbridge-indexer-core/Api/BulkRequestInterface.php
+++ b/src/module-vsbridge-indexer-core/Api/BulkRequestInterface.php
@@ -28,6 +28,13 @@ interface BulkRequestInterface
     public function getOperations();
 
     /**
+     * @param array $data
+     *
+     * @return array
+     */
+    public function prepareDocument(array $data);
+
+    /**
      * Add a several documents to the index.
      *
      * $data format have to be an array of all documents with document id as key.

--- a/src/module-vsbridge-indexer-core/Index/BulkRequest.php
+++ b/src/module-vsbridge-indexer-core/Index/BulkRequest.php
@@ -56,10 +56,22 @@ class BulkRequest implements BulkRequestInterface
     public function addDocuments($index, $type, array $data)
     {
         foreach ($data as $docId => $documentData) {
+            $documentData = $this->prepareDocument($documentData);
             $this->addDocument($index, $type, $docId, $documentData);
         }
 
         return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function prepareDocument(array $data)
+    {
+        unset($data['entity_id']);
+        unset($data['row_id']);
+
+        return $data;
     }
 
     /**
@@ -86,6 +98,7 @@ class BulkRequest implements BulkRequestInterface
     public function updateDocuments($index, $type, array $data)
     {
         foreach ($data as $docId => $documentData) {
+            $documentData = $this->prepareDocument($documentData);
             $this->updateDocument($index, $type, $docId, $documentData);
         }
 

--- a/src/module-vsbridge-indexer-core/Index/ConvertDataTypes.php
+++ b/src/module-vsbridge-indexer-core/Index/ConvertDataTypes.php
@@ -42,9 +42,6 @@ class ConvertDataTypes implements ConvertDataTypesInterface
             $mappingProperties = $mapping->getMappingProperties()['properties'];
 
             foreach ($docs as $docId => $indexData) {
-                unset($indexData['entity_id']);
-                unset($indexData['row_id']);
-
                 $indexData = $this->convert($indexData, $mappingProperties);
 
                 if (isset($indexData['configurable_children'])) {

--- a/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
@@ -178,22 +178,24 @@ class GenericIndexerHandler
                     }
                 }
 
-                $docs = $this->convertDataTypes->castFieldsUsingMapping($type, $docs);
-                $bulkRequest = $this->indexOperation->createBulk()->addDocuments(
-                    $index->getName(),
-                    $this->typeName,
-                    $docs
-                );
+                if (!empty($docs)) {
+                    $docs = $this->convertDataTypes->castFieldsUsingMapping($type, $docs);
+                    $bulkRequest = $this->indexOperation->createBulk()->addDocuments(
+                        $index->getName(),
+                        $this->typeName,
+                        $docs
+                    );
 
-                $response = $this->indexOperation->executeBulk($bulkRequest);
-                $this->logErrors($response);
-                $this->eventManager->dispatch(
-                    'search_engine_save_documents_after',
-                    [
-                        'data_type' => $this->typeName,
-                        'bulk_response' => $response,
-                    ]
-                );
+                    $response = $this->indexOperation->executeBulk($bulkRequest);
+                    $this->logErrors($response);
+                    $this->eventManager->dispatch(
+                        'search_engine_save_documents_after',
+                        [
+                            'data_type' => $this->typeName,
+                            'bulk_response' => $response,
+                        ]
+                    );
+                }
 
                 $docs = null;
             }


### PR DESCRIPTION
Log error to file instead of throwing exception.