### PR TITLE
Add Elasticsearch index version support using aliases

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/Attribute.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/Attribute.php
@@ -92,4 +92,13 @@ class Attribute implements \Magento\Framework\Indexer\ActionInterface, \Magento\
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/Category.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/Category.php
@@ -102,4 +102,13 @@ class Category implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/Product.php
@@ -103,4 +103,13 @@ class Product implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fr
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/ProductCategory.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/ProductCategory.php
@@ -112,4 +112,13 @@ class ProductCategory implements \Magento\Framework\Indexer\ActionInterface, \Ma
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-cms/Model/Indexer/CmsBlock.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/CmsBlock.php
@@ -90,4 +90,13 @@ class CmsBlock implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-cms/Model/Indexer/CmsPage.php
+++ b/src/module-vsbridge-indexer-cms/Model/Indexer/CmsPage.php
@@ -90,4 +90,13 @@ class CmsPage implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fr
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-core/Config/IndicesSettings.php
+++ b/src/module-vsbridge-indexer-core/Config/IndicesSettings.php
@@ -49,6 +49,14 @@ class IndicesSettings
     }
 
     /**
+     * @return string
+     */
+    public function getUseVersioning()
+    {
+        return (bool) $this->getConfigParam('use_versioning');
+    }    
+
+    /**
      * @return int
      */
     public function getBatchIndexingSize()

--- a/src/module-vsbridge-indexer-core/Elasticsearch/Client.php
+++ b/src/module-vsbridge-indexer-core/Elasticsearch/Client.php
@@ -141,4 +141,54 @@ class Client implements ClientInterface
 
         return $this->client;
     }
+
+    /**
+     * $params['index']   = (list) A comma-separated list of index names to filter aliases
+     *        ['timeout'] = (time) Explicit timestamp for the document
+     *        ['body']    = (time) Explicit timestamp for the document
+     *
+     * @param $params array Associative array of parameters
+     *
+     */
+    public function updateAliases($params = array()) {
+        $this->getClient()->indices()->updateAliases($params);
+    }
+
+    /**
+     * $params['local']   = (bool) Return local information, do not retrieve the state from master node (default: false)
+     *        ['timeout'] = (time) Explicit timestamp for the document
+     *
+     * @param $params array Associative array of parameters
+     *
+     * @return array
+     */
+    public function getAliases($params)
+    {
+        return $this->getClient()->indices()->getAliases($params);
+    }
+
+    /**
+     * $params['index'] = (list) A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+     *
+     * @param $params array Associative array of parameters
+     *
+     * @return array
+     */
+    public function getSettings($params)
+    {
+        return $this->getClient()->indices()->getSettings($params);
+    }
+
+    /**
+     * $params['index'] = (list) A comma-separated list of index names; use `_all` or empty string for all indices
+     *        ['type']  = (list) A comma-separated list of document types
+     *
+     * @param $params array Associative array of parameters
+     *
+     * @return array
+     */
+    public function getMapping($params = array())
+    {
+        return $this->getClient()->indices()->getMapping($params);
+    }
 }

--- a/src/module-vsbridge-indexer-core/Index/IndexSettings.php
+++ b/src/module-vsbridge-indexer-core/Index/IndexSettings.php
@@ -89,6 +89,14 @@ class IndexSettings
     }
 
     /**
+     * @return string
+     */
+    public function getUseVersioning()
+    {
+        return $this->settingConfig->getUseVersioning();
+    }
+
+    /**
      * @return int
      */
     public function getBatchIndexingSize()

--- a/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
@@ -71,6 +71,11 @@ class GenericIndexerHandler
     private $logger;
 
     /**
+     * @var array
+     */
+    protected $newIndex;
+
+    /**
      * IndexerHandler constructor.
      *
      * @param ClientInterface $client
@@ -254,6 +259,10 @@ class GenericIndexerHandler
      */
     private function getIndex(StoreInterface $store)
     {
+        $storeId = $store->getId();
+        if (isset($this->newIndex[$storeId])) {
+            return $this->newIndex[$storeId];
+        }
         try {
             $index = $this->indexOperation->getIndexByName($this->indexIdentifier, $store);
         } catch (\Exception $e) {
@@ -261,6 +270,18 @@ class GenericIndexerHandler
         }
 
         return $index;
+    }
+
+    /**
+     * @param IndexInterface $index
+     *
+     * @return $this
+     */
+    public function setNewIndex(IndexInterface $index, $storeId)
+    {
+        $this->newIndex[$storeId] = $index;
+
+        return $this;
     }
 
     /**

--- a/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
+++ b/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
@@ -83,6 +83,11 @@
                     <comment>Choose if the index will append the Store ID or Store Code to the index name, e.g. "vue_storefront_magento_1" or "vue_storefront_magento_default"</comment>
                     <source_model>Divante\VsbridgeIndexerCore\Model\Config\Source\IndexIdentifier</source_model>
                 </field>
+                <field id="use_versioning" translate="label comment" type="select" sortOrder="270" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Use Versioning</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Uses only in case of running bin/magento vsbridge:reindex from shell</comment>
+                </field>
                 <field id="fields_limit" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>The maximum number of fields in an index</label>
                     <comment>min value: 1000</comment>

--- a/src/module-vsbridge-indexer-core/etc/config.xml
+++ b/src/module-vsbridge-indexer-core/etc/config.xml
@@ -18,6 +18,7 @@
             <indices_settings>
                 <batch_indexing_size>1000</batch_indexing_size>
                 <index_name>vue_storefront_magento</index_name>
+                <use_versioning>1</use_versioning>
                 <index_identifier>id</index_identifier>
                 <fields_limit>1000</fields_limit>
                 <category_products_update>0</category_products_update>

--- a/src/module-vsbridge-indexer-review/Model/Indexer/Review.php
+++ b/src/module-vsbridge-indexer-review/Model/Indexer/Review.php
@@ -91,4 +91,13 @@ class Review implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fra
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }

--- a/src/module-vsbridge-indexer-tax/Model/Indexer/TaxRules.php
+++ b/src/module-vsbridge-indexer-tax/Model/Indexer/TaxRules.php
@@ -90,4 +90,13 @@ class TaxRules implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
     {
         $this->execute([$id]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNewIndex($index, $storeId)
+    {
+        $this->indexHandler->setNewIndex($index, $storeId);
+        return $this;
+    }
 }


### PR DESCRIPTION
In case of changing mapping for some attributes current  indexer functionality support only delete index and create new one. But for live inviromnet is important to not have index be deleted. So the best way for this use indexe with versions and alias. in this case product export  processes to the new index created  and changes alias at the end. 