### PR TITLE
Fix exporting all tax rates to ES. 

### DIFF
--- a/src/module-vsbridge-indexer-tax/ResourceModel/Rates.php
+++ b/src/module-vsbridge-indexer-tax/ResourceModel/Rates.php
@@ -50,7 +50,7 @@ class Rates
             ->where('tax_calculation_rule_id IN (?)', $ruleIds);
         $select->distinct(true);
 
-        return $this->getConnection()->fetchAssoc($select);
+        return $this->getConnection()->fetchAll($select);
     }
 
     /**


### PR DESCRIPTION
Was not seeing all the TaxRates defined in Magento2 in ES unless this was set to fetchAll on my Magento 2 with TaxJar integration