### PR TITLE
Rework abstract mapper to allow configure static type map in di.xml

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/AbstractMapping.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/AbstractMapping.php
@@ -13,16 +13,17 @@ abstract class AbstractMapping
     /**
      * @var array
      */
-    private $staticFieldMapping = [
-        'status' => FieldInterface::TYPE_INTEGER,
-        'visibility' => FieldInterface::TYPE_INTEGER,
-        'position' => FieldInterface::TYPE_LONG,
-        'level' => FieldInterface::TYPE_INTEGER,
-        'category_ids' => FieldInterface::TYPE_LONG,
-        'sku' => FieldInterface::TYPE_KEYWORD,
-        'url_path' => FieldInterface::TYPE_KEYWORD,
-        'url_key' => FieldInterface::TYPE_KEYWORD,
-    ];
+    private $staticFieldMapping;
+
+    /**
+     * AbstractMapping constructor.
+     *
+     * @param array $staticFieldMapping
+     */
+    public function __construct(array $staticFieldMapping)
+    {
+        $this->staticFieldMapping = $staticFieldMapping;
+    }
 
     /**
      * @var array

--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Category.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Category.php
@@ -20,7 +20,6 @@ use Magento\Framework\Event\ManagerInterface as EventManager;
  */
 class Category extends AbstractMapping implements MappingInterface
 {
-
     /**
      * @var array
      */
@@ -61,17 +60,20 @@ class Category extends AbstractMapping implements MappingInterface
      * @param GeneralMapping $generalMapping
      * @param CategoryChildAttributes $categoryChildAttributes
      * @param AttributeDataProvider $resourceModel
+     * @param array $staticFieldMapping
      */
     public function __construct(
         EventManager $eventManager,
         GeneralMapping $generalMapping,
         CategoryChildAttributes $categoryChildAttributes,
-        AttributeDataProvider $resourceModel
+        AttributeDataProvider $resourceModel,
+        array $staticFieldMapping
     ) {
         $this->eventManager = $eventManager;
         $this->generalMapping = $generalMapping;
         $this->resourceModel = $resourceModel;
         $this->childAttributes = $categoryChildAttributes;
+        parent::__construct($staticFieldMapping);
     }
 
     /**

--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
@@ -14,7 +14,6 @@ use Magento\Framework\Event\ManagerInterface as EventManager;
  */
 class Product extends AbstractMapping implements MappingInterface
 {
-
     /**
      * @var EventManager
      */
@@ -52,12 +51,14 @@ class Product extends AbstractMapping implements MappingInterface
         EventManager $eventManager,
         GeneralMapping $generalMapping,
         ConfigurableAttributes $configurableAttributes,
-        AttributeDataProvider $resourceModel
+        AttributeDataProvider $resourceModel,
+        array $staticFieldMapping
     ) {
         $this->eventManager = $eventManager;
         $this->generalMapping = $generalMapping;
         $this->resourceModel = $resourceModel;
         $this->configurableAttributes = $configurableAttributes;
+        parent::__construct($staticFieldMapping);
     }
 
     /**

--- a/src/module-vsbridge-indexer-catalog/etc/di.xml
+++ b/src/module-vsbridge-indexer-catalog/etc/di.xml
@@ -137,4 +137,18 @@
     <type name="Magento\CatalogInventory\Observer\ReindexQuoteInventoryObserver">
         <plugin name="update_product_in_es" type="Divante\VsbridgeIndexerCatalog\Plugin\Indexer\CatalogInventory\ReindexQuoteInventoryObserverPlugin"/>
     </type>
+    <type name="Divante\VsbridgeIndexerCatalog\Index\Mapping\AbstractMapping">
+        <arguments>
+            <argument name="staticFieldMapping" xsi:type="array">
+                <item name="status" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_INTEGER</item>
+                <item name="visibility" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_INTEGER</item>
+                <item name="position" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_LONG</item>
+                <item name="level" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_INTEGER</item>
+                <item name="category_ids" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_LONG</item>
+                <item name="sku" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_KEYWORD</item>
+                <item name="url_path" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_KEYWORD</item>
+                <item name="url_key" xsi:type="const">Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface::TYPE_KEYWORD</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Currently staticFieldMapping is in private field which is not possible to extend or reach by any manner. Also no public can be plugined to add or change static mapping. Only overriding is viable but overriding is BAD as we all know and all classes attributes are private and also some methods are.

I moved staticFieldMapping from a private attribute to a constructor so anyone can configure list simply by adding or changing it from di.xml. That will make that class a little bit more open for changes (SOLID) without changing the class itself.

I encountered a real life scenario where I had to be sure that an attribute will be of given type and I did not find any good solution.