### PR TITLE
Aliases - fixes.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [1.5.1]
+
+### Fixes
+-  Fix Notice: Undefined index: value in ConfigurableData.php on line 254 ([#139](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/139))
+-  Switch indices when all types will be reindex ([#138](https://github.com/DivanteLtd/magento2-vsbridge-indexer/pull/138))
+-  Change method name `AbstractEavAttributes:canReindex:canReindex` to 'cantReindexAttribute'
+
 ## [1.5.0]
 
 ### Changed/Improved

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sign up for a demo at https://vuestorefront.io/ (Vue Storefront integrated with 
 
 ## Overview
 
-### Version 1.5.0 - support for aliases.
+### Version 1.5.1 - support for aliases.
 Command ` php bin/magento vsbridge:reindex` will reindex all data to new index.
 It will create new index and update aliases at the end.
 
@@ -27,6 +27,7 @@ If you won't do that, you will get error when running
 
 - Install with composer
 ```json
+composer config repositories.divante vcs https://github.com/DivanteLtd/magento2-vsbridge-indexer
 composer require divante/magento2-vsbridge-indexer
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "name": "Agata",
     "email": "afirlejczyk@divante.pl"
   }],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "keywords": [
     "magento",
     "magento2",

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
@@ -88,7 +88,7 @@ abstract class AbstractEavAttributes implements EavAttributesInterface
         $selects = [];
 
         foreach ($this->attributesById as $attributeId => $attribute) {
-            if ($this->canReindex($attribute, $requiredAttributes)) {
+            if ($this->canReindexAttribute($attribute, $requiredAttributes)) {
                 $tableAttributes[$attribute->getBackendTable()][] = $attributeId;
 
                 if (!isset($attributeTypes[$attribute->getBackendTable()])) {
@@ -121,7 +121,7 @@ abstract class AbstractEavAttributes implements EavAttributesInterface
      * @return bool
      * @throws \Exception
      */
-    public function canReindex(\Magento\Eav\Model\Entity\Attribute $attribute, array $allowedAttributes = null)
+    public function canReindexAttribute(\Magento\Eav\Model\Entity\Attribute $attribute, array $allowedAttributes = null)
     {
         if ($attribute->isStatic()) {
             return false;

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/EavAttributesInterface.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/EavAttributesInterface.php
@@ -30,5 +30,5 @@ interface EavAttributesInterface
      *
      * @return bool
      */
-    public function canReindex(\Magento\Eav\Model\Entity\Attribute $attribute, array $allowedAttributes = null);
+    public function canReindexAttribute(\Magento\Eav\Model\Entity\Attribute $attribute, array $allowedAttributes = null);
 }

--- a/src/module-vsbridge-indexer-core/Index/IndexOperations.php
+++ b/src/module-vsbridge-indexer-core/Index/IndexOperations.php
@@ -216,7 +216,7 @@ class IndexOperations implements IndexOperationInterface
                 ];
             }
         }
-
+        
         $this->client->updateAliases($aliasActions);
 
         foreach ($deletedIndices as $deletedIndex) {
@@ -227,6 +227,7 @@ class IndexOperations implements IndexOperationInterface
     /**
      * @param $indexIdentifier
      * @param StoreInterface $store
+     * @param bool $existingIndex
      *
      * @return Index
      */

--- a/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php
@@ -14,11 +14,12 @@ use Divante\VsbridgeIndexerCore\Api\ConvertDataTypesInterface;
 use Divante\VsbridgeIndexerCore\Api\IndexInterface;
 use Divante\VsbridgeIndexerCore\Api\IndexOperationInterface;
 use Divante\VsbridgeIndexerCore\Api\Indexer\TransactionKeyInterface;
+use Divante\VsbridgeIndexerCore\Exception\ConnectionDisabledException;
+use Divante\VsbridgeIndexerCore\Model\IndexerRegistry as IndexerRegistry;
 use Magento\Framework\Indexer\SaveHandler\Batch;
 use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Store\Api\Data\StoreInterface;
 use Psr\Log\LoggerInterface;
-use Divante\VsbridgeIndexerCore\Exception\ConnectionDisabledException;
 
 /**
  * Class IndexerHandler
@@ -34,6 +35,11 @@ class GenericIndexerHandler
      * @var \Divante\VsbridgeIndexerCore\Index\IndexOperations
      */
     private $indexOperation;
+
+    /**
+     * @var IndexerRegistry
+     */
+    private $indexerRegistry;
 
     /**
      * @var ClientInterface
@@ -71,12 +77,13 @@ class GenericIndexerHandler
     private $logger;
 
     /**
-     * IndexerHandler constructor.
+     * GenericIndexerHandler constructor.
      *
      * @param ClientInterface $client
      * @param LoggerInterface $logger
      * @param IndexOperationInterface $indexOperation
      * @param ConvertDataTypesInterface $convertDataTypes
+     * @param IndexerRegistry $indexerRegistry
      * @param EventManager $eventManager
      * @param Batch $batch
      * @param TransactionKeyInterface $transactionKey
@@ -88,6 +95,7 @@ class GenericIndexerHandler
         LoggerInterface $logger,
         IndexOperationInterface $indexOperation,
         ConvertDataTypesInterface $convertDataTypes,
+        IndexerRegistry $indexerRegistry,
         EventManager $eventManager,
         Batch $batch,
         TransactionKeyInterface $transactionKey,
@@ -101,6 +109,7 @@ class GenericIndexerHandler
         $this->convertDataTypes = $convertDataTypes;
         $this->typeName = $typeName;
         $this->indexIdentifier = $indexIdentifier;
+        $this->indexerRegistry = $indexerRegistry;
         $this->eventManager = $eventManager;
         $this->transactionKey = $transactionKey->load();
     }
@@ -201,7 +210,7 @@ class GenericIndexerHandler
                 $docs = null;
             }
 
-            if ($index->isNew()) {
+            if ($index->isNew() && !$this->indexerRegistry->isFullReIndexationRunning()) {
                 $this->indexOperation->switchIndexer($index->getName(), $index->getIdentifier());
             }
 

--- a/src/module-vsbridge-indexer-core/Model/IndexerRegistry.php
+++ b/src/module-vsbridge-indexer-core/Model/IndexerRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Divante\VsbridgeIndexerCore\Model;
+
+/**
+ * Class IndexerRegistry
+ */
+class IndexerRegistry
+{
+    /**
+     * @var bool
+     */
+    private $isFullReIndexationRunning = false;
+
+    /**
+     * @return bool
+     */
+    public function isFullReIndexationRunning()
+    {
+        return $this->isFullReIndexationRunning;
+    }
+
+    /**
+     * @return void
+     */
+    public function setFullReIndexationIsInProgress()
+    {
+        $this->isFullReIndexationRunning = true;
+    }
+}


### PR DESCRIPTION
Support for aliases - fix for running full re indexation with `vsbridge:reindex` command.
Index alias was added to fast to new index, now alias will be added after data for all types has been exported.