### PR TITLE
Add input argument for reindexing specific indexer.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Add support for indexer input argument. Works the same as Magento's native reindexer where you can pass a space separated list of 1 or more indexer names to specifically reindex. If none are provided all vsbridge indexers are reindexed. [@rain2o](https://github.com/rain2o) ([#100](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/100))
+
 ## [1.5.1]
 
 ### Fixes


### PR DESCRIPTION
Closes #100 

Adds the optional indexer input argument which works the same way as Magento's native reindex command. Now you can run, for example, `bin/magento vsbridge:reindex vsbridge_product_indexer` to reindex only the Product indexer. This input argument accepts a list of space separated indexers, so you can run as many as you like - `bin/magento vsbridge:reindex vsbridge_product_indexer vsbridge_category_indexer` for example.

The argument is optional, so if nothing is provided it works the same as before where it reindexes all `vsbridge_*` indexers.