### PR TITLE
Add new command to run Magento indexer for one entity. #100.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,19 +2,27 @@
 
 ## Unreleased
 
-## [1.5.2]
+### Added
+- Add new command `vsbridge:index` to run indexer for one product, cms block, etc. 
+`bin/magento vsbridge:index vsbridge_product_indexer default 1`
+vsbridge_product_indexer -> indexer code
+default -> store code
+1 -> entity id (in this particular example - product id)
+Useful for testing. 
+
+## [1.5.2] (2019.10.24)
 
 ### Fixes
  - Run `vsbridge:reindex` command only if all indices has valid status.
 
-## [1.5.1]
+## [1.5.1] (2019.10.23)
 
 ### Fixes
 -  Fix Notice: Undefined index: value in ConfigurableData.php on line 254 ([#139](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/139))
 -  Switch indices when all types will be reindex ([#138](https://github.com/DivanteLtd/magento2-vsbridge-indexer/pull/138))
 -  Change method name `AbstractEavAttributes:canReindex` to '`AbstractEavAttributes:canIndexAttribute`
 
-## [1.5.0]
+## [1.5.0] (2019.10.18)
 
 ### Changed/Improved
 -  Change method `AbstractEavAttributes:canReindex` to public ([#136](https://github.com/DivanteLtd/magento2-vsbridge-indexer/pull/136)) 

--- a/src/module-vsbridge-indexer-core/Console/Command/SingleEntityIndexCommand.php
+++ b/src/module-vsbridge-indexer-core/Console/Command/SingleEntityIndexCommand.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * @package  Divante\VsbridgeIndexerCore
+ * @author Agata Firlejczyk <afirlejczyk@divante.pl>
+ * @copyright 2019 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Divante\VsbridgeIndexerCore\Console\Command;
+
+use Divante\VsbridgeIndexerCore\Indexer\StoreManager;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Indexer\Console\Command\AbstractIndexerCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Store\Model\StoreManagerInterface as StoreManagerInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class SingleEntityIndexCommand
+ */
+class SingleEntityIndexCommand extends AbstractIndexerCommand
+{
+    const INPUT_STORE = 'store';
+
+    const INPUT_INDEXER_CODE = 'index';
+
+    const INPUT_ENTITY_ID = 'id';
+
+    /**
+     * @var StoreManager
+     */
+    private $indexerStoreManager;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var array
+     */
+    private $excludeIndices = [];
+
+    /**
+     * RebuildEsIndexCommand constructor.
+     *
+     * @param ObjectManagerFactory $objectManagerFactory
+     * @param array $excludeIndices
+     */
+    public function __construct(
+        ObjectManagerFactory $objectManagerFactory,
+        array $excludeIndices = []
+    ) {
+        $this->excludeIndices = $excludeIndices;
+        parent::__construct($objectManagerFactory);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName('vsbridge:index')
+            ->setDescription(
+                'Update single entity in ES (product, category, attribute,  etc..). Useful tool for testing new data.'
+            );
+
+        $this->setDefinition($this->getInputList());
+
+        parent::configure();
+    }
+
+    /**
+     * Get list of options and arguments for the command
+     *
+     * @return array
+     */
+    private function getInputList()
+    {
+        return [
+            new InputArgument(
+                self::INPUT_INDEXER_CODE,
+                InputArgument::REQUIRED ,
+                'Indexer code'
+            ),
+            new InputArgument(
+                self::INPUT_STORE,
+                InputArgument::REQUIRED ,
+                'Store ID or Store Code'
+            ),
+            new InputArgument(
+                self::INPUT_ENTITY_ID,
+                InputArgument::REQUIRED ,
+                'Entity id'
+            ),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->initObjectManager();
+        $output->setDecorated(true);
+
+        $storeId = $input->getArgument(self::INPUT_STORE);
+        $index = $input->getArgument(self::INPUT_INDEXER_CODE);
+        $id = $input->getArgument(self::INPUT_ENTITY_ID);
+
+        $store = $this->getStoreManager()->getStore($storeId);
+        $this->getIndexerStoreManager()->setLoadedStores([$store]);
+        $indexer = $this->getIndex($index);
+
+        if ($indexer) {
+            $message = "\nIndex: " . $indexer->getTitle() .
+                "\nStore: " . $store->getName() .
+                "\nID: " . $id;
+            $output->writeln("<info>Indexing... $message</info>");
+            $indexer->reindexRow($id);
+        } else {
+            $output->writeln("<info>Index with code: $index hasn't been found. </info>");
+        }
+    }
+
+    /**
+     * @return IndexerInterface
+     */
+    private function getIndex($code)
+    {
+        /** @var IndexerInterface[] */
+        $indexers = $this->getAllIndexers();
+        $vsbridgeIndexers = [];
+
+        foreach ($indexers as $indexer) {
+            $indexId = $indexer->getId();
+
+            if ($code === $indexId) {
+                return $indexer;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return StoreManagerInterface
+     */
+    private function getStoreManager()
+    {
+        if (null === $this->storeManager) {
+            $this->storeManager = $this->getObjectManager()->get(StoreManagerInterface::class);
+        }
+
+        return $this->storeManager;
+    }
+
+    /**
+     * @return StoreManager
+     */
+    private function getIndexerStoreManager()
+    {
+        if (null === $this->indexerStoreManager) {
+            $this->indexerStoreManager = $this->getObjectManager()->get(StoreManager::class);
+        }
+
+        return $this->indexerStoreManager;
+    }
+
+    /**
+     * Initiliaze object manager
+     */
+    private function initObjectManager()
+    {
+        $this->getObjectManager();
+    }
+}

--- a/src/module-vsbridge-indexer-core/etc/di.xml
+++ b/src/module-vsbridge-indexer-core/etc/di.xml
@@ -63,6 +63,7 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
+                <item name="index_single_entity" xsi:type="object">Divante\VsbridgeIndexerCore\Console\Command\SingleEntityIndexCommand</item>
                 <item name="rebuild" xsi:type="object">Divante\VsbridgeIndexerCore\Console\Command\RebuildEsIndexCommand</item>
             </argument>
         </arguments>


### PR DESCRIPTION
- Add new command `vsbridge:index` to run indexer for one product, cms block, etc. 
`bin/magento vsbridge:index vsbridge_product_indexer default 1`
vsbridge_product_indexer -> indexer code
default -> store code
1 -> entity id (in this particular example - product id)

Useful for testing. 