### PR TITLE
Add image filename as required attribute for child categories

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/Attributes/CategoryChildAttributes.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Attributes/CategoryChildAttributes.php
@@ -21,6 +21,7 @@ class CategoryChildAttributes
         'is_active',
         'url_path',
         'url_key',
+        'image',
     ];
 
     /**


### PR DESCRIPTION
We needed this for one of our websites and thought other people might also need it in the future.