### PR TITLE
Widget rendering error in cms block/pages

### DIFF
--- a/src/module-vsbridge-indexer-cms/etc/di.xml
+++ b/src/module-vsbridge-indexer-cms/etc/di.xml
@@ -33,4 +33,20 @@
     <type name="Magento\Cms\Model\Block">
         <plugin name="update_block_data_in_elastic" type="Divante\VsbridgeIndexerCms\Plugin\Indexer\Block\Save\UpdateCmsBlock"/>
     </type>
+    <virtualType name="WidgetEmulateFilterProvider" type="Magento\Cms\Model\Template\FilterProvider">
+        <arguments>
+            <argument name="pageFilter" xsi:type="string">Magento\Widget\Model\Template\FilterEmulate</argument>
+            <argument name="blockFilter" xsi:type="string">Magento\Widget\Model\Template\FilterEmulate</argument>
+        </arguments>
+    </virtualType>
+    <type name="Divante\VsbridgeIndexerCms\Model\Indexer\Action\CmsBlock">
+        <arguments>
+            <argument name="filterProvider" xsi:type="object">WidgetEmulateFilterProvider</argument>
+        </arguments>
+    </type>
+    <type name="Divante\VsbridgeIndexerCms\Model\Indexer\Action\CmsPage">
+        <arguments>
+            <argument name="filterProvider" xsi:type="object">WidgetEmulateFilterProvider</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
PR fixes problem with indexing CMS block and pages which has widget in their content.

The problem occurs in 2 cases:
1. With the indexer set as "On Schedule"
2. With the indexer set as "On Save" and reindexing is triggered from a different area than "frontend" 

During indexing, the default area is set as "global" and Magento throws an exception "Invalid template file..." because widget template is being searched in the global area instead of "frontend". Magento has a prepared class for that case `Magento\Widget\Model\Template\FilterEmulate` which emulates the frontend area for rendering widget content.

