### PR TITLE
Fix incorrect value for max_sale_qty

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixed
+- Fixed `max_sale_qty` getting wrong value when set per-product. [@rain2o](https://github.com/rain2o) ([#201](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/201))
 
 ## [1.9.0] (2020.01.28)
 

--- a/src/module-vsbridge-indexer-catalog/Model/InventoryProcessor.php
+++ b/src/module-vsbridge-indexer-catalog/Model/InventoryProcessor.php
@@ -55,7 +55,7 @@ class InventoryProcessor
         }
 
         if (!empty($inventory[StockItemInterface::USE_CONFIG_MIN_SALE_QTY])) {
-            $inventory['max_sale_qty'] = $this->stockConfiguration->getMinSaleQty($storeId);
+            $inventory['min_sale_qty'] = $this->stockConfiguration->getMinSaleQty($storeId);
         }
 
         if (!empty($inventory[StockItemInterface::USE_CONFIG_MAX_SALE_QTY])) {


### PR DESCRIPTION
Closes #201 

Looks like `max_sale_qty` was getting assigned two values, and Min Sale Qty was winning when the values are set per-product instead of with global configs. Now it is assigning the min and max values accordingly.