### PR TITLE
Fix idAttributes to match the new xml structure

### DIFF
--- a/src/module-vsbridge-indexer-core/Index/Indicies/Config/Reader.php
+++ b/src/module-vsbridge-indexer-core/Index/Indicies/Config/Reader.php
@@ -27,8 +27,7 @@ class Reader extends Filesystem
      */
     private $idAttributes = [
         '/indices/index' => 'identifier',
-        '/indices/index/type' => 'name',
-        '/indices/index/type/data_providers/data_provider' => 'name',
+        '/indices/index/data_providers/data_provider' => 'name',
     ];
 
     /**


### PR DESCRIPTION
Hi,

in the new xml structure for `vsbridge_indices.xml` the `<type>`-node is no longer available. This pr should fix the xml merging for mulitple `vsbridge_indices.xml` files with the same index name.

I came across this issue, because I wanted to add an additional data provider.

Thanks and Greetings