### PR TITLE
Check for bundle selection scoped price per website

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- If price scope is set to per Website, check for bundle selection price per website, falling back to global if none found. - [@rain2o](https://github.com/rain2o)
+
 ### Added
 - Add option to export data for store views to different ES instances
 

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Bundle.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Bundle.php
@@ -72,7 +72,6 @@ class Bundle
         $this->productMetaData = $productMetaData;
         $this->storeManager = $storeManager;
         $this->catalogHelper = $catalogHelper;
-        parent::__construct($productMetaData, $resourceModel);
     }
 
     /**
@@ -151,9 +150,11 @@ class Bundle
     /**
      * Append Selection
      *
+     * @param int $storeId
+     *
      * @return void
      */
-    private function initSelection($storeId)
+    private function initSelection(int $storeId)
     {
         $bundleSelections = $this->getBundleSelections($storeId);
         $simpleIds = array_column($bundleSelections, 'product_id');
@@ -196,7 +197,7 @@ class Bundle
         );
         $productIdColumn = 'parent_product_id';
 
-        if (!$this->catalogHelper->isPriceGlobal() && $storeId) {
+        if (!$this->catalogHelper->isPriceGlobal()) {
             $websiteId = $this->storeManager->getStore($storeId)
                 ->getWebsiteId();
             $priceType = $connection->getCheckSql(


### PR DESCRIPTION
This is an anticipatory fix to account for a Magento 2 bug fix that is currently being reviewed. See [magento/magento2#27315](https://github.com/magento/magento2/pull/27315).

The original issue with Magento was that when you set the configuration of Price Scope to be "WEBSITE", the bundle option item prices are not saved properly per website. Once the linked PR is approved and merged, this PR will account for the scoped prices when indexing the bundle products.

As a note, this modification shouldn't make any difference before the Magento bug is fixed, as it performs a check to see if there are any scoped prices and falls back to the global price if not. With that said, if you want to test and merge this before the Magento PR, it should mean this module will be compatible with the update if/when it goes through.

For reference, I took the code from `source/vendor/magento/module-bundle/Model/ResourceModel/Selection/Collection.php::joinPrices()` to use the same logic Magento core uses when pulling Bundle products with prices.