### PR TITLE
Add a setting for adding the date to the index name

### DIFF
--- a/src/module-vsbridge-indexer-core/Config/IndicesSettings.php
+++ b/src/module-vsbridge-indexer-core/Config/IndicesSettings.php
@@ -57,6 +57,14 @@ class IndicesSettings
     }
 
     /**
+     * @return bool
+     */
+    public function addDateToIndexName()
+    {
+        return (bool) $this->getConfigParam('add_date_to_index_name');
+    }
+
+    /**
      * @return int
      */
     public function getBatchIndexingSize()

--- a/src/module-vsbridge-indexer-core/Index/IndexSettings.php
+++ b/src/module-vsbridge-indexer-core/Index/IndexSettings.php
@@ -2,8 +2,10 @@
 
 namespace Divante\VsbridgeIndexerCore\Index;
 
+use DateTime;
 use Divante\VsbridgeIndexerCore\Index\Indicies\Config as IndicesConfig;
 use Divante\VsbridgeIndexerCore\Config\IndicesSettings;
+use Exception;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -66,7 +68,7 @@ class IndexSettings
                         'filter' => ['lowercase'],
                     ],
                     'autocomplete_search' => [
-                        'tokenizer'=> 'lowercase'
+                        'tokenizer' => 'lowercase'
                     ]
                 ],
                 'tokenizer' => [
@@ -85,13 +87,19 @@ class IndexSettings
      * @param StoreInterface $store
      *
      * @return string
+     * @throws Exception
      */
     public function createIndexName(StoreInterface $store)
     {
         $name = $this->getIndexAlias($store);
-        $currentDate = new \DateTime();
 
-        return $name . '_' . $currentDate->getTimestamp();
+        if ($this->settingConfig->addDateToIndexName()) {
+            $currentDate = new DateTime();
+            $name = $name . '_' . $currentDate->getTimestamp();
+        }
+
+
+        return $name;
     }
 
     /**
@@ -126,7 +134,7 @@ class IndexSettings
             }
         }
 
-        return ('code' === $this->getIndexIdentifier()) ? $store->getCode() : (string) $store->getId();
+        return ('code' === $this->getIndexIdentifier()) ? $store->getCode() : (string)$store->getId();
     }
 
     /**

--- a/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
+++ b/src/module-vsbridge-indexer-core/etc/adminhtml/system.xml
@@ -87,6 +87,10 @@
                     <label>Add Index Identifier to Default Store View</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="add_date_to_index_name" translate="label comment" type="select" sortOrder="250" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Add Date to Index Name</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="fields_limit" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>The maximum number of fields in an index</label>
                     <comment>min value: 1000</comment>

--- a/src/module-vsbridge-indexer-core/etc/config.xml
+++ b/src/module-vsbridge-indexer-core/etc/config.xml
@@ -20,6 +20,7 @@
                 <index_name>vue_storefront_magento</index_name>
                 <index_identifier>id</index_identifier>
                 <add_identifier_to_default>1</add_identifier_to_default>
+                <add_date_to_index_name>1</add_date_to_index_name>
                 <fields_limit>1000</fields_limit>
                 <category_products_update>0</category_products_update>
             </indices_settings>


### PR DESCRIPTION
By default, the Magento 2 Indexer creates a new ElasticSearch index that includes the Index Alias Prefix, the Store Code or Store ID and a timestamp. This timestamp is causing index settings in the `config/local.json` files of both PWA and API to be out of sync, once the ElasticSearch indices are wiped and re-created. This PR adds a simple setting to disable adding the timestamp to the index name, while it still defaults to the original behaviour.