### PR TITLE
Classify a message in the log as INFO instead of ERROR

### DIFF
--- a/src/module-vsbridge-indexer-core/Cache/Processor.php
+++ b/src/module-vsbridge-indexer-core/Cache/Processor.php
@@ -110,7 +110,7 @@ class Processor
         }
 
         foreach ($batches as $batch) {
-            $this->logger->error('BATCHES ' . implode(', ', $batch));
+            $this->logger->info('BATCHES ' . implode(', ', $batch));
             $cacheInvalidateUrl = $this->getCacheInvalidateUrl($storeId, $dataType, $entityIds);
 
             try {

--- a/src/module-vsbridge-indexer-core/Cache/Processor.php
+++ b/src/module-vsbridge-indexer-core/Cache/Processor.php
@@ -110,7 +110,7 @@ class Processor
         }
 
         foreach ($batches as $batch) {
-            $this->logger->info('BATCHES ' . implode(', ', $batch));
+            $this->logger->debug('BATCHES ' . implode(', ', $batch));
             $cacheInvalidateUrl = $this->getCacheInvalidateUrl($storeId, $dataType, $entityIds);
 
             try {


### PR DESCRIPTION
That is infact no error, but should just be a debug or info.