### PR TITLE
Port product mapping event dispatcher from 1.10.1

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
@@ -80,7 +80,16 @@ class Product extends AbstractMapping implements MappingInterface
             $properties = array_merge($properties, $attributesMapping);
             $properties = array_merge($properties, $this->generalMapping->getCommonProperties());
 
-            $this->properties = ['properties' => $properties];
+            $mapping = ['properties' => $properties];
+            $mappingObject = new \Magento\Framework\DataObject();
+            $mappingObject->setData($mapping);
+
+            $this->eventManager->dispatch(
+                'elasticsearch_product_mapping_properties',
+                ['mapping' => $mappingObject]
+            );
+
+            $this->properties = $mappingObject->getData();
         }
 
         return $this->properties;

--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
@@ -10,12 +10,18 @@ use Divante\VsbridgeIndexerCore\Api\Mapping\FieldInterface;
 use Divante\VsbridgeIndexerCore\Api\MappingInterface;
 use Divante\VsbridgeIndexerCore\Index\Mapping\GeneralMapping;
 use Divante\VsbridgeIndexerCatalog\Model\ResourceModel\Product\LoadAttributes;
+use Magento\Framework\Event\ManagerInterface as EventManager;
 
 /**
  * Class Product
  */
 class Product extends AbstractMapping implements MappingInterface
 {
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
     /**
      * @var GeneralMapping
      */
@@ -51,6 +57,7 @@ class Product extends AbstractMapping implements MappingInterface
      * @param array $additionalMapping
      */
     public function __construct(
+        EventManager $eventManager,
         GeneralMapping $generalMapping,
         StockMapping $stockMapping,
         LoadAttributes $resourceModel,

--- a/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Index/Mapping/Product.php
@@ -64,6 +64,7 @@ class Product extends AbstractMapping implements MappingInterface
         array $staticFieldMapping,
         array $additionalMapping
     ) {
+        $this->eventManager = $eventManager;
         $this->stockMapping = $stockMapping;
         $this->generalMapping = $generalMapping;
         $this->resourceModel = $resourceModel;


### PR DESCRIPTION
Seems this was removed under "minor refactoring" adding it back to easily modify the product mapping.

https://github.com/DivanteLtd/magento2-vsbridge-indexer/commit/db8450da2dde41e0573ca8e12c06889ca0a5da06