### PR TITLE
fixed expression to select subcategories

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category/StoreSelectModifier.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Category/StoreSelectModifier.php
@@ -50,7 +50,7 @@ class StoreSelectModifier implements BaseSelectModifierInterface
 
         $rootId = Category::TREE_ROOT_ID;
         $rootCatIdExpr = $connection->quote(sprintf("%s/%s", $rootId, $store->getRootCategoryId()));
-        $catIdExpr = $connection->quote(sprintf("%s/%s%%", $rootId, $store->getRootCategoryId()));
+        $catIdExpr = $connection->quote(sprintf("%s/%s/%%", $rootId, $store->getRootCategoryId()));
         $whereCondition = sprintf("path = %s OR path like %s", $rootCatIdExpr, $catIdExpr);
 
         $select->where($whereCondition);


### PR DESCRIPTION
The old expression '1/2%' included 1/2/3 as well as 1/23456789. This led to inclusion of categories in from a wrong store in the index.