### PR TITLE
Add ability to use a text swatch attribute.

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/Attribute/LoadOptions.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Attribute/LoadOptions.php
@@ -161,7 +161,8 @@ class LoadOptions
      */
     private function isVisualSwatch(Attribute $attribute)
     {
-        return $attribute->getData('swatch_input_type') === Swatch::SWATCH_INPUT_TYPE_VISUAL;
+        return $attribute->getData('swatch_input_type') === Swatch::SWATCH_INPUT_TYPE_VISUAL
+            || $attribute->getData('swatch_input_type') === Swatch::SWATCH_INPUT_TYPE_TEXT;
     }
 
     /**


### PR DESCRIPTION
This change enables indexing of text-swatches (basically the same as visual-swatches, with text value instead of hex code).

```
{
  "options": [
    {
      "swatch": {
        "type": 0,
        "value": "XL"
      },
      "label": "Extra large",
      "value": "5749",
      "sort_order": 1
    }
  ]

}