### PR TITLE
:sparkles: (Added events to reindex command.)

### DIFF
--- a/src/module-vsbridge-indexer-core/Console/Command/RebuildEsIndexCommand.php
+++ b/src/module-vsbridge-indexer-core/Console/Command/RebuildEsIndexCommand.php
@@ -14,6 +14,7 @@ use Divante\VsbridgeIndexerCore\Api\Index\IndexOperationProviderInterface;
 use Divante\VsbridgeIndexerCore\Model\IndexerRegistry;
 use Magento\Framework\App\ObjectManagerFactory;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Indexer\Console\Command\AbstractIndexerCommand;
@@ -60,17 +61,25 @@ class RebuildEsIndexCommand extends AbstractIndexerCommand
     private $excludeIndices = [];
 
     /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
      * RebuildEsIndexCommand constructor.
      *
-     * @param ObjectManagerFactory $objectManagerFactory
-     * @param array $excludeIndices
+     * @param  ObjectManagerFactory  $objectManagerFactory
+     * @param  ManagerInterface  $eventManager
+     * @param  array  $excludeIndices
      */
     public function __construct(
         ObjectManagerFactory $objectManagerFactory,
+        ManagerInterface $eventManager, // Proxy
         array $excludeIndices = []
     ) {
         $this->excludeIndices = $excludeIndices;
         parent::__construct($objectManagerFactory);
+        $this->eventManager = $eventManager;
     }
 
     /**
@@ -152,6 +161,10 @@ class RebuildEsIndexCommand extends AbstractIndexerCommand
      */
     private function reindex(OutputInterface $output, $storeId, $allStores)
     {
+        $this->eventManager->dispatch('vsbridge_indexer_reindex_before', [
+            'storeId' => $storeId,
+            'allStores' => $allStores,
+        ]);
 
         if ($storeId) {
             $store = $this->getStoreManager()->getStore($storeId);
@@ -182,6 +195,11 @@ class RebuildEsIndexCommand extends AbstractIndexerCommand
             // If failure returned in any store return failure now
             return in_array(Cli::RETURN_FAILURE, $returnValues) ? Cli::RETURN_FAILURE : Cli::RETURN_SUCCESS;
         }
+
+        $this->eventManager->dispatch('vsbridge_indexer_reindex_after', [
+            'storeId' => $storeId,
+            'allStores' => $allStores,
+        ]);
     }
 
     /**

--- a/src/module-vsbridge-indexer-core/etc/di.xml
+++ b/src/module-vsbridge-indexer-core/etc/di.xml
@@ -72,4 +72,10 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Divante\VsbridgeIndexerCore\Console\Command\RebuildEsIndexCommand">
+        <arguments>
+            <argument name="eventManager" xsi:type="object">Magento\Framework\Event\ManagerInterface\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Hi,

unfortunately, the whole reindexing logic lives inside of private or protected methods which makes it impossible to customize or extend it. To not be forced to overwrite the whole thing, I added two events that are triggered before and after the full reindex process.

This would also solve our issue in [Issue 266](https://github.com/DivanteLtd/magento2-vsbridge-indexer/issues/266).

I made the additional dependency a proxy, to make sure there are no issues regarding the performance or future maintainability. 