### PR TITLE
Add a product's missing 'created_at'  values

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product.php
@@ -136,6 +136,7 @@ class Product
         $columns = [
             'entity_id',
             'attribute_set_id',
+            'created_at',
             'updated_at',
             'type_id',
             'sku',


### PR DESCRIPTION
\Divante\VsbridgeIndexerCore\Index\Mapping\GeneralMapping::$commonProperties defines that the 'created_at' value should be indexed in the VSF catalog bridge indexer. The 'created_at' values are however missing. This fix adds the "created at" values for products.