### PR TITLE
Run Vsbridge Dataprovider before Custom Dataproviders

### DIFF
--- a/src/module-vsbridge-indexer-core/Index/Type.php
+++ b/src/module-vsbridge-indexer-core/Index/Type.php
@@ -72,6 +72,7 @@ class Type implements TypeInterface
      */
     public function getDataProviders()
     {
+        ksort($this->dataProviders);
         return $this->dataProviders;
     }
 


### PR DESCRIPTION
#316 Run Vsbridge Dataprovider before Custom Dataproviders 

module-vsbridge-indexer-core/Indexer/GenericIndexerHandler.php line 165
without sorting, the custom data providers are called before the core data providers
but the only with the core data providers the necessary attribute values are added
only if we have the attribute values, we can implement logic based on Attribute Indexes
there is no option to sort data providers by xml