### PR TITLE
Configurable products now use the correct language version of attribute label

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Product/ConfigurableData.php
+++ b/src/module-vsbridge-indexer-catalog/Model/Indexer/DataProvider/Product/ConfigurableData.php
@@ -152,7 +152,7 @@ class ConfigurableData implements DataProviderInterface
         }
 
         $stockRowData = $this->loadInventory->execute($allChildren, $storeId);
-        $configurableAttributeCodes = $this->configurableResource->getConfigurableAttributeCodes();
+        $configurableAttributeCodes = $this->configurableResource->getConfigurableAttributeCodes($storeId);
 
         $allChildren = $this->childrenAttributeProcessor
             ->execute($storeId, $allChildren, $configurableAttributeCodes);
@@ -203,7 +203,7 @@ class ConfigurableData implements DataProviderInterface
     {
         $configurableChildren = $productDTO['configurable_children'];
         $productAttributeOptions =
-            $this->configurableResource->getProductConfigurableAttributes($productDTO);
+            $this->configurableResource->getProductConfigurableAttributes($productDTO, $storeId);
 
         $productDTO['configurable_children'] = $configurableChildren;
 

--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Configurable.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Configurable.php
@@ -144,7 +144,7 @@ class Configurable
      * @return array
      * @throws \Exception
      */
-    public function getProductConfigurableAttributes(array $product)
+    public function getProductConfigurableAttributes(array $product, $storeId)
     {
         if ($product['type_id'] != ConfigurableType::TYPE_CODE) {
             return [];
@@ -156,7 +156,7 @@ class Configurable
             return [];
         }
 
-        $attributes = $this->getConfigurableAttributeFullInfo();
+        $attributes = $this->getConfigurableAttributeFullInfo($storeId);
         $data = [];
 
         foreach ($attributeIds as $attributeId) {
@@ -237,9 +237,9 @@ class Configurable
      * @return array
      * @throws \Exception
      */
-    public function getConfigurableAttributeCodes()
+    public function getConfigurableAttributeCodes($storeId)
     {
-        $attributes = $this->getConfigurableAttributeFullInfo();
+        $attributes = $this->getConfigurableAttributeFullInfo($storeId);
 
         return array_column($attributes, 'attribute_code');
     }
@@ -251,7 +251,7 @@ class Configurable
      * @return array
      * @throws \Exception
      */
-    private function getConfigurableAttributeFullInfo()
+    private function getConfigurableAttributeFullInfo($storeId)
     {
         if (null === $this->configurableAttributesInfo) {
             // build list of all configurable attribute codes for the current collection
@@ -267,7 +267,7 @@ class Configurable
                         $this->configurableAttributesInfo[$attributeId] = [
                             'attribute_id' => (int)$attributeId,
                             'attribute_code' => $attributeModel->getAttributeCode(),
-                            'label' => $attributeModel->getStoreLabel(),
+                            'label' => $attributeModel->getStoreLabel($storeId),
                         ];
                     }
                 }


### PR DESCRIPTION
The label provided for the `configurable_options` field is now using the label assigned for the currently active store.