### PR TITLE
Fixed exception: Unable to apply data patch Magento\Catalog\Setup\Pat…

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Setup/UpgradeData/SetCategoryDefaultAttributes.php
+++ b/src/module-vsbridge-indexer-catalog/Setup/UpgradeData/SetCategoryDefaultAttributes.php
@@ -52,15 +52,19 @@ class SetCategoryDefaultAttributes
         /** @var UpdateAttributesInConfiguration $updateConfiguration */
         $updateConfiguration = $this->updateAttributesInConfiguration->create(['entityType' => 'catalog_category']);
 
-        $updateConfiguration->execute(
-            $this->mainAttributes,
-            $this->getConfigPath(CategoryConfigInterface::CATEGORY_ATTRIBUTES)
-        );
+        if (!empty($this->mainAttributes)) {
+            $updateConfiguration->execute(
+                $this->mainAttributes,
+                $this->getConfigPath(CategoryConfigInterface::CATEGORY_ATTRIBUTES)
+            );
+        }
 
-        $updateConfiguration->execute(
-            $this->childAttributes,
-            $this->getConfigPath(CategoryConfigInterface::CHILD_ATTRIBUTES)
-        );
+        if (!empty($this->childAttributes)) {
+            $updateConfiguration->execute(
+                $this->childAttributes,
+                $this->getConfigPath(CategoryConfigInterface::CHILD_ATTRIBUTES)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
…ch\Data\InstallDefaultCategories for module Magento_Catalog. Original exception message: Invalid entity_type  specified: catalog_category