### PR TITLE
Sort linked products by position

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Links.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/Product/Links.php
@@ -116,6 +116,16 @@ class Links
                     ];
                 }
             }
+            
+            // sort list by position
+            usort($linkProductList, function ($a, $b) {
+                $aPosition = $a['position'];
+                $bPosition = $b['position'];
+                if ($aPosition == $bPosition) {
+                    return 0;
+                }
+                return ($aPosition > $bPosition) ? +1 : -1;
+            });
 
             return $linkProductList;
         }


### PR DESCRIPTION
Hi,

currently the linked products (related, crosssell, upsell) are not ordered by the position, that is set in the magento backend. This tiny PR fixes the problem. 

Could you take a look and merge it?

Thanks!
