### PR TITLE
PHP 8.1 Deprecated Functionality in explode()

### DIFF
--- a/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
+++ b/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php
@@ -172,7 +172,7 @@ abstract class AbstractEavAttributes implements EavAttributesInterface
             $attributeCode = $attribute->getAttributeCode();
 
             if ($attribute->getFrontendInput() === 'multiselect') {
-                $options = explode(',', $value['value']);
+                $options = explode(',', $value['value'] ?? '');
 
                 if (!empty($options)) {
                     $options = array_map([$this, 'parseValue'], $options);


### PR DESCRIPTION
Hi,

Upgrading to PHP 8.1, we get the following error:

`Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in vendor/divante/magento2-vsbridge-indexer/src/module-vsbridge-indexer-catalog/Model/ResourceModel/AbstractEavAttributes.php on line 176`